### PR TITLE
Retrieve raw content for curling PR template

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ download the template you would like to use, you can run the following
 cURL command:
 
 ```
-curl -O https://github.com/echobind/pr-templates/blob/master/frontend/PULL_REQUEST_TEMPLATE
+curl -O https://raw.githubusercontent.com/echobind/pr-templates/master/frontend/PULL_REQUEST_TEMPLATE
 ```
 
 Every template is named `PULL_REQUEST_TEMPLATE` for easy installation, so you


### PR DESCRIPTION
Updates the README for this repo to correctly fetch the content of the PR template using the raw url from Github.

## Changes

- Updates README to look at `raw.githubusercontent.com` instead of `github.com`

## PR Template Checklist

- [x] Grammar
- [x] Spelling
- [x] Clarity

Fixes #7 
